### PR TITLE
uses readlink and dirname

### DIFF
--- a/gcam
+++ b/gcam
@@ -1,2 +1,6 @@
 #!/bin/bash
-python3 ./src/__main__.py "$@"
+
+path=$(readlink "$0" || echo "$0")
+path=$(dirname "$path")
+
+python3 "$path/src/__main__.py" "$@"


### PR DESCRIPTION
Instead of expecting the user to be in the current working directory of the checked out repository, `dirname` can be used to put the checked out repository in `PATH`.